### PR TITLE
Chore/keep alive connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (options) => {
 
     const { keepAlive, keepAliveTimer: keepAliveTimerParam } = config;
     if (keepAliveTimerParam && (isNaN(keepAliveTimerParam) || keepAliveTimerParam <= 0)) {
-      throw new Error(`${keepAliveTimer} is not a valid number.`);
+      throw new Error(`${keepAliveTimerParam} is not a valid number.`);
     }
     // 30 seconds by default
     const keepAliveTimer = keepAliveTimerParam ? keepAliveTimerParam * 1000 : 30000;

--- a/index.js
+++ b/index.js
@@ -32,6 +32,13 @@ module.exports = (options) => {
       throw new Error('config is required');
     }
 
+    const { keepAlive, keepAliveTimer: keepAliveTimerParam } = config;
+    if (keepAliveTimerParam && (isNaN(keepAliveTimerParam) || keepAliveTimerParam <= 0)) {
+      throw new Error(`${keepAliveTimer} is not a valid number.`);
+    }
+    // 30 seconds by default
+    const keepAliveTimer = keepAliveTimerParam ? keepAliveTimerParam * 1000 : 30000;
+
     ({ logger } = dependencies);
 
     if (!logger) {
@@ -46,6 +53,14 @@ module.exports = (options) => {
     } else {
       await connectToRedis();
     }
+
+    /**
+     * Redis instances in Azure disconnect the client after an IDLE time causing a forced reconnection.
+     * https://gist.github.com/JonCole/925630df72be1351b21440625ff2671f#file-redis-bestpractices-node-js-md
+     */
+     keepAlive && setInterval(() => {
+      client.ping();
+    }, keepAliveTimer);
 
     return client;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,42 @@
 {
   "name": "systemic-redis",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-redis",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A systemic redis component",
   "main": "index.js",
   "engineStrict": true,
@@ -18,7 +18,7 @@
   "author": "GuideSmiths Ltd",
   "license": "ISC",
   "dependencies": {
-    "redis": "^3.0.2"
+    "redis": "^3.1.2"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
The new  _**keepAlive**_ option is not enabled by default. Some Redis servers closes the connection after a period of inactivity from the client instance. That's the case for the Azure Cache for Redis resource.