### PR TITLE
fix: after updating redis dep config was not being parsed as expected

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,14 @@ module.exports = (options) => {
       logger = console;
     }
 
-    logger.info(`Connecting to ${config.url || config.host || '127.0.0.1'}`);
-    client = redis.createClient(config);
+    // https://github.com/redis/node-redis#basic-example
+    const host = config.url || config.host || '127.0.0.1';
+    const protocol = config.tls ? 'rediss://' : 'redis://';
+    logger.info(`Connecting to ${host} with protocol ${protocol} based on TLS config`);
+    client = redis.createClient({
+      url: protocol + '@' + host + ':' + config.port,
+      password: config.password,
+  });
 
     if (config.no_ready_check) {
       connectToRedis();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "systemic-redis",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "systemic-redis",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "redis": "^4.3.1"


### PR DESCRIPTION
New `redis` dependency was not being able to parse systemic instance config keeping the original configuration on the services.