### PR TITLE
refactor: replace custom features with native ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,6 @@ module.exports = (options) => {
       throw new Error('config is required');
     }
 
-    const { keepAlive, keepAliveTimer: keepAliveTimerParam } = config;
-    if (keepAliveTimerParam && (isNaN(keepAliveTimerParam) || keepAliveTimerParam <= 0)) {
-      throw new Error(`${keepAliveTimerParam} is not a valid number.`);
-    }
-    // 30 seconds by default
-    const keepAliveTimer = keepAliveTimerParam ? keepAliveTimerParam * 1000 : 30000;
-
     ({ logger } = dependencies);
 
     if (!logger) {
@@ -28,26 +21,30 @@ module.exports = (options) => {
 
     // https://github.com/redis/node-redis#basic-example
     const host = config.url || config.host || '127.0.0.1';
-    const protocol = config.tls ? 'rediss://' : 'redis://';
-    logger.info(`Connecting to ${host} with protocol ${protocol} based on TLS config`);
+    const database = config.db || 0;
+    let protocol = 'redis://';
+    const socket = {
+      connectTimeout: 10000,
+      keepAlive: 5000,
+    };
+    if (config.tls) {
+      protocol = 'rediss://';
+      socket.tls = true;
+      socket.servername = host;
+    }
+    const url = protocol + host + ':' + config.port + '/' + database;
+    logger.info(`Connecting ${url}`);
     client = redis.createClient({
-      url: protocol + '@' + host + ':' + config.port,
+      url,
       password: config.password,
-  });
+      socket,
+    });
 
     if (config.no_ready_check) {
       connectToRedis();
     } else {
       await connectToRedis();
     }
-
-    /**
-     * Redis instances in Azure disconnect the client after an IDLE time causing a forced reconnection.
-     * https://gist.github.com/JonCole/925630df72be1351b21440625ff2671f#file-redis-bestpractices-node-js-md
-     */
-    keepAlive && setInterval(() => {
-      client.ping();
-    }, keepAliveTimer);
 
     return client;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-redis",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A systemic redis component",
   "main": "index.js",
   "engineStrict": true,


### PR DESCRIPTION
Since latest `redis` dependency version supports some native features that we needed to implement manually in the past we refactored that features.

One of that features replaced by the native behavior is the socket `keepAlive` functionality which was a custom implementation.

Also the connection url is now fully logged except for sensible data like the instance password.