### PR TITLE
Fix/missing re connect strategy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         node-version: [14.x, 16.x, 18.x]
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   systemic-redis-defaults:
     image: redis:4-alpine3.11
     container_name: systemic-redis-defaults
+    command: redis-server --requirepass systemic-redis-defaults
     ports:
       - 6379:6379
     networks:

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (options) => {
       connectTimeout: 10000,
       keepAlive: 5000,
       reconnectStrategy: retries => {
-        console.log('Reconnect attempt', retries);
+        logger.info('Reconnect attempt', retries);
         return 4000;
       }
     };

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (options) => {
       connectTimeout: 10000,
       keepAlive: 5000,
       reconnectStrategy: retries => {
-        console.log('Reconnect attempt', retries);
+        logger.info('Reconnect attempt', retries);
         return 3000;
       }
     };

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (options) => {
       connectTimeout: 10000,
       keepAlive: 5000,
       reconnectStrategy: retries => {
-        logger.info('Reconnect attempt', retries);
+        logger.info(`Reconnect attempt ${retries}`);
         return 4000;
       }
     };
@@ -57,11 +57,10 @@ module.exports = (options) => {
 
     // Without handling incoming server errors the process would get finished
     client.on('error', error => {
-      console.log(error.message)
       if (error.message === 'ERR invalid password') {
         throw error;
       }
-      logger.error("client err", error);
+      logger.error(`Client err: ${JSON.stringify(error)}`);
     });
 
     client.on('reconnecting', () => {

--- a/index.js
+++ b/index.js
@@ -56,11 +56,11 @@ module.exports = (options) => {
 
     // Without handling incoming server errors the process would get finished
     client.on("error", error => {
-      console.error("client err", error);
+      logger.error("client err", error);
     });
 
     client.on('reconnecting', () => {
-      console.info(`Redis client is reconnecting to ${url}...`)
+      logger.info(`Redis client is reconnecting to ${url}...`)
     })
 
     if (config.no_ready_check) {

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ module.exports = (options) => {
       connectTimeout: 10000,
       keepAlive: 5000,
       reconnectStrategy: retries => {
-        logger.info('Reconnect attempt', retries);
-        return 3000;
+        console.log('Reconnect attempt', retries);
+        return 4000;
       }
     };
     if (config.tls) {
@@ -52,16 +52,21 @@ module.exports = (options) => {
 
     client.on('ready', () => {
       logger.info(`Connected ${url}`);
-    })
+    });
+
 
     // Without handling incoming server errors the process would get finished
-    client.on("error", error => {
+    client.on('error', error => {
+      console.log(error.message)
+      if (error.message === 'ERR invalid password') {
+        throw error;
+      }
       logger.error("client err", error);
     });
 
     client.on('reconnecting', () => {
       logger.info(`Redis client is reconnecting to ${url}...`)
-    })
+    });
 
     if (config.no_ready_check) {
       connectToRedis();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,6 +2310,15 @@
         "path-type": "^4.0.0"
       }
     },
+    "docker-compose": {
+      "version": "0.23.17",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.17.tgz",
+      "integrity": "sha512-YJV18YoYIcxOdJKeFcCFihE6F4M2NExWM/d4S1ITcS9samHKnNUihz9kjggr0dNtsrbpFNc7/Yzd19DWs+m1xg==",
+      "dev": true,
+      "requires": {
+        "yaml": "^1.10.2"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint . --ext .js",
     "lint:fix": "npm run lint -- --fix",
-    "test": "npx jest",
+    "test": "npx jest --forceExit",
     "docker:start": "docker-compose up -d",
     "docker:stop": "docker-compose down",
     "release": "commit-and-tag-version"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "commit-and-tag-version": "^10.1.0",
+    "docker-compose": "^0.23.17",
     "eslint": "^8.23.1",
     "husky": "^8.0.1",
     "jest": "^29.0.3",

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -1,3 +1,4 @@
+jest.setTimeout(10000);
 const systemImage = require('./system');
 const redisSystem = require('../index');
 const dockerCompose = require('docker-compose');
@@ -43,7 +44,7 @@ describe('systemic-redis', () => {
       });
     });
 
-    it.only('reconnect strategy', async () => {
+    it('reconnect strategy', async () => {
       system.set('config', { host: 'localhost', port: 6379 });
       system.set('redis', redisSystem()).dependsOn('config');
       const { redis: instance } = await system.start();

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -1,4 +1,4 @@
-jest.setTimeout(10000);
+jest.setTimeout(15000);
 const systemImage = require('./system');
 const redisSystem = require('../index');
 const dockerCompose = require('docker-compose');
@@ -14,7 +14,7 @@ describe('systemic-redis', () => {
         await system.start();
         throw new Error('This line should not be executed never');
       } catch (error) {
-        expect(error.message).toBe('Unhandled error. ([ErrorReply: ERR Client sent AUTH, but no password is set])');
+        expect(error.message).toBe('ERR invalid password');
       }
     });
   });
@@ -24,7 +24,7 @@ describe('systemic-redis', () => {
 
     describe('redis instance connect', () => {
       it('defaults', async () => {
-        system.set('config', { host: 'localhost', port: 6379 });
+        system.set('config', { host: 'localhost', password: 'systemic-redis-defaults', port: 6379 });
         system.set('redis', redisSystem()).dependsOn('config');
         const { redis: instance } = await system.start();
 
@@ -45,7 +45,7 @@ describe('systemic-redis', () => {
     });
 
     it('reconnect strategy', async () => {
-      system.set('config', { host: 'localhost', port: 6379 });
+      system.set('config', { host: 'localhost', password: 'systemic-redis-defaults', port: 6379 });
       system.set('redis', redisSystem()).dependsOn('config');
       const { redis: instance } = await system.start();
 


### PR DESCRIPTION
Since some connections may **not be stable** or the server **could be rebooted** because of many reasons the client instances show expect that kind of error events.

There was not strategy for handling socket connection errors. That's why some node processes using this package got an unexpected shutdown exit code status.

Handling connection errors and having defined a **_reconnect strategy_** now would guarantee us that the process would keep trying to reconnect every three seconds once the connection got lost with the server.